### PR TITLE
check displayName presence

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -51,7 +51,7 @@ export const findMatchingSuggestions = prefix => arrayOfdocgenObjects => {
     return [];
   }
   const matchingDocgenObjects = arrayOfdocgenObjects.filter(({ displayName }) =>
-    displayName.startsWith(prefix)
+    (typeof displayName != 'undefined') && displayName.startsWith(prefix)
   );
   return matchingDocgenObjects.map(mapDocgenToAutocomplete);
 };


### PR DESCRIPTION
Fixes an issue when package fails with an error, in case an included component does not have propTypes defined at all (I do so for components without props)